### PR TITLE
fix: Remove redefinition of apply_headers from class Discourse::Cors

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,27 +4,6 @@
 # authors: @debtcollective
 
 after_initialize do
-  # This is needed by the dc-vue-header in order to work
-  class Discourse::Cors
-    def self.apply_headers(cors_origins, env, headers)
-      origin = nil
-
-      if cors_origins
-        if origin = env['HTTP_ORIGIN']
-          origin = nil unless cors_origins.include?(origin)
-        end
-
-        headers['Access-Control-Allow-Origin'] = origin || cors_origins[0]
-        headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-CSRF-Token, Discourse-Visible'
-        headers['Access-Control-Expose-Headers'] = 'X-Discourse-Username'
-        headers['Access-Control-Allow-Credentials'] = 'true'
-        headers['Access-Control-Allow-Methods'] = 'HEAD, OPTIONS, GET, DELETE'
-      end
-
-      headers
-    end
-  end
-
   # SSO payload to return whitelisted user custom_fields
   module DebtCollectiveSessionController
     def sso_provider(payload = nil)


### PR DESCRIPTION
**What:** Remove redefinition of CORS apply headers method

The current Discourse logic after setting CORS enabled can be found at https://bit.ly/2WTENK7 and it
already allows POST, PUT, GET, OPTIONS, DELETE. With that being said, the previous definition within
this plugin seems to limit the functionality instead enhance it

_BREAKING CHANGE_: Potentially this can break expectations from dc-vue-header component described at https://bit.ly/2IgCwVd

related https://github.com/debtcollective/header/issues/5

**Why:** As we need to be able to mark notifications as read by using PUT method from outside Discourse application

**How:** Remove code that replaces Discourse definition for headers under CORS