### PR TITLE
fix: use avatar_template_url to get CDN urls instead of direct s3 urls

### DIFF
--- a/lib/sso.rb
+++ b/lib/sso.rb
@@ -40,14 +40,7 @@ module DebtCollective
     private
 
     def user_avatar_url
-      avatar_url = @user.small_avatar_url
-
-      if @user.uploaded_avatar.present?
-        base_url = Discourse.store.external? ? "#{Discourse.store.absolute_base_url}/" : Discourse.base_url
-        avatar_url = "#{base_url}#{Discourse.store.get_path_for_upload(@user.uploaded_avatar)}"
-      end
-
-      avatar_url
+      @user.avatar_template_url.gsub('{size}', '100')
     end
 
     def user_profile_background_url
@@ -81,7 +74,6 @@ module DebtCollective
         active: @user.active,
         admin: @user.admin?,
         avatar_url: user_avatar_url,
-        card_background_url: user_card_background_url,
         created_at: @user.created_at,
         custom_fields: user_custom_fields,
         email: @user.email,
@@ -90,7 +82,6 @@ module DebtCollective
         last_seen_at: @user.last_seen_at,
         moderator: @user.moderator?,
         name: @user.name,
-        profile_background_url: user_profile_background_url,
         updated_at: @user.updated_at,
         username: @user.username,
       }

--- a/plugin.rb
+++ b/plugin.rb
@@ -50,18 +50,6 @@ after_initialize do
           # this method return either a letter avatar or the cdn upload
           sso.avatar_url = current_user.avatar_template_url.gsub('{size}', '100')
 
-          if current_user.user_profile.profile_background_upload.present?
-            sso.profile_background_url = UrlHelper.absolute(upload_cdn_path(
-              current_user.user_profile.profile_background_upload.url
-            ))
-          end
-
-          if current_user.user_profile.card_background_upload.present?
-            sso.card_background_url = UrlHelper.absolute(upload_cdn_path(
-              current_user.user_profile.card_background_upload.url
-            ))
-          end
-
           # return user fields
           sso.custom_fields["user_state"] = current_user.custom_fields.fetch("user_field_1", "").to_s
           sso.custom_fields["user_zip"] = current_user.custom_fields.fetch("user_field_2", "").to_s

--- a/plugin.rb
+++ b/plugin.rb
@@ -47,14 +47,8 @@ after_initialize do
           sso.moderator = current_user.moderator?
           sso.groups = current_user.groups.pluck(:name).join(",")
 
-          if current_user.uploaded_avatar.present?
-            base_url = Discourse.store.external? ? "#{Discourse.store.absolute_base_url}/" : Discourse.base_url
-            avatar_url = "#{base_url}#{Discourse.store.get_path_for_upload(current_user.uploaded_avatar)}"
-            sso.avatar_url = UrlHelper.absolute Discourse.store.cdn_url(avatar_url)
-          else
-            # return letter_avatar if no uploaded_avatar
-            sso.avatar_url = current_user.small_avatar_url
-          end
+          # this method return either a letter avatar or the cdn upload
+          sso.avatar_url = current_user.avatar_template_url.gsub('{size}', '100')
 
           if current_user.user_profile.profile_background_upload.present?
             sso.profile_background_url = UrlHelper.absolute(upload_cdn_path(


### PR DESCRIPTION
**What:** Use `avatar_template_url` instead of the provided methods by Discourse.

**Why:** Fixes https://app.asana.com/0/1159164196409156/1163415196941332

**How:**

The issue we are having is since we made our S3 buckets private, Discourse generates by default S3 bucket URLs. We are serving our assets with a CDN (Cloudfront), and it looks like this isn't taken into account when generating URLs by Discourse (a bug in Discourse)

Here's the code in Discourse we are changing https://github.com/discourse/discourse/blob/master/app/controllers/session_controller.rb#L80-L84