### PR TITLE
use parent scope controller when referencing Users::AssociateAccountsController

### DIFF
--- a/lib/extensions/users/omniauth_callbacks_controller.rb
+++ b/lib/extensions/users/omniauth_callbacks_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # https://github.com/discourse/discourse/blob/master/app/controllers/users/omniauth_callbacks_controller.rb
 module Debtcollective
   module Users
@@ -14,7 +15,7 @@ module Debtcollective
         if session.delete(:auth_reconnect) && authenticator.can_connect_existing_user? && current_user
           # Save to redis, with a secret token, then redirect to confirmation screen
           token = SecureRandom.hex
-          Discourse.redis.setex "#{Users::AssociateAccountsController::REDIS_PREFIX}_#{current_user.id}_#{token}", 10.minutes, auth.to_json
+          Discourse.redis.setex "#{::Users::AssociateAccountsController::REDIS_PREFIX}_#{current_user.id}_#{token}", 10.minutes, auth.to_json
           return redirect_to Discourse.base_uri("/associate/#{token}")
         else
           @auth_result = authenticator.after_authenticate(auth)


### PR DESCRIPTION
**What:** use parent scope controller when referencing Users::AssociateAccountsController

**Why:** Fixes https://app.asana.com/0/1168997577035609/1181281014749029

**How:**

- Look for `Users::AssociateAccountsController` in parent scope