### PR TITLE
Extend users profile after signup.

### DIFF
--- a/app/jobs/extend_user_profile.rb
+++ b/app/jobs/extend_user_profile.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Jobs
+  class ExtendUserProfile < ::Jobs::Base
+    def execute(args)
+      user = User.find(id: args[:user_id])
+
+      Debtcollective::UserProfileService.execute(user)
+    end
+  end
+end

--- a/app/jobs/extend_user_profile.rb
+++ b/app/jobs/extend_user_profile.rb
@@ -2,7 +2,7 @@
 module Jobs
   class ExtendUserProfile < ::Jobs::Base
     def execute(args)
-      user = User.find(id: args[:user_id])
+      user = User.find(args[:user_id])
 
       Debtcollective::UserProfileService.execute(user)
     end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,1 +1,8 @@
 en:
+  admin_js:
+    admin:
+      user_fields:
+        field_types:
+          phone-number: 'US - Phone Number'
+          zip-code: 'US - Zip Code'
+          state: 'US - State'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,3 +1,5 @@
 en:
   site_settings:
-    enable_debtcollective_sso: "Enable debtcollective-sso plugin"
+    enable_debtcollective_sso: 'Enable debtcollective-sso plugin'
+    debtcollective_algolia_app_id: 'Algolia Places App ID'
+    debtcollective_algolia_api_key: 'Algolia Places API key'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,11 +2,17 @@ plugins:
   enable_debtcollective_sso:
     default: true
   sso_cookie_domain:
-    default: ".lvh.me"
+    default: '.lvh.me'
     shadowed_by_global: true
   sso_cookie_name:
-    default: "tdc_auth_token"
+    default: 'tdc_auth_token'
     shadowed_by_global: true
   sso_jwt_secret:
-    default: "changeme"
+    default: 'changeme'
+    shadowed_by_global: true
+  debtcollective_algolia_app_id:
+    default: ''
+    shadowed_by_global: true
+  debtcollective_algolia_api_key:
+    default: ''
     shadowed_by_global: true

--- a/lib/algolia_places_client.rb
+++ b/lib/algolia_places_client.rb
@@ -1,10 +1,39 @@
 # frozen_string_literal: true
+require 'net/http'
+require 'uri'
+
 module Debtcollective
   class AlgoliaPlacesClient
-    attr_reader :client
+    attr_reader :app_id, :api_key, :api_url
 
     def initialize(app_id: nil, api_key: nil)
       return nil unless app_id.present? && api_key.present?
+
+      self.app_id = app_id
+      self.api_key = api_key
+      self.api_url = 'https://places-dsn.algolia.net/1/places/query'
+    end
+
+    # Returns HTTP::Response
+    def query(query, options = { type: "address", "restrictSearchableAttributes": "postcode", hitsPerPage: 1 })
+      payload = { query: query }.merge(options)
+
+      Net::HTTP.post(
+        URI(self.api_url),
+        payload.to_json,
+        self.headers
+      )
+    end
+
+    private
+
+    def headers
+      {
+        accept: "application/json",
+        "Content-Type": "application/json",
+        "X-Algolia-Application-Id": self.app_id,
+        "X-Algolia-API-Key": self.api_key
+      }
     end
   end
 end

--- a/lib/algolia_places_client.rb
+++ b/lib/algolia_places_client.rb
@@ -38,7 +38,7 @@ module Debtcollective
         city: result['city']['default'].first,
         country: result['country']['default'],
         country_code: result['country_code'],
-        county: result['country']['default'].first,
+        county: result['county']['default'].first,
         objectID: result['objectID'],
         geoloc: result['_geoloc'],
         postcodes: result['postcode'],

--- a/lib/algolia_places_client.rb
+++ b/lib/algolia_places_client.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Debtcollective
+  class AlgoliaPlacesClient
+    attr_reader :client
+
+    def initialize(app_id: nil, api_key: nil)
+      return nil unless app_id.present? && api_key.present?
+    end
+  end
+end

--- a/lib/algolia_places_client.rb
+++ b/lib/algolia_places_client.rb
@@ -19,7 +19,10 @@ module Debtcollective
       when Net::HTTPSuccess then
         success_response(response)
       else
-        # TODO: track error with sentry?
+        if Module.const_defined?('Raven')
+          Raven.capture_message("Error while making Algolia Places request", extra: { status: response.status, body: response.body })
+        end
+
         nil
       end
     end
@@ -39,10 +42,10 @@ module Debtcollective
         country_code: result['country_code'],
         county: result['country']['default'].first,
         objectID: result['objectID'],
+        geoloc: result['_geoloc'],
         postcodes: result['postcode'],
         state: result['administrative'].first
-      }
-
+      }.with_indifferent_access
     end
 
     def self.headers

--- a/lib/algolia_places_client.rb
+++ b/lib/algolia_places_client.rb
@@ -4,35 +4,53 @@ require 'uri'
 
 module Debtcollective
   class AlgoliaPlacesClient
-    attr_reader :app_id, :api_key, :api_url
-
-    def initialize(app_id: nil, api_key: nil)
-      return nil unless app_id.present? && api_key.present?
-
-      self.app_id = app_id
-      self.api_key = api_key
-      self.api_url = 'https://places-dsn.algolia.net/1/places/query'
-    end
-
-    # Returns HTTP::Response
-    def query(query, options = { type: "address", "restrictSearchableAttributes": "postcode", hitsPerPage: 1 })
+    # Returns JSON response or nil
+    def self.query(query, options = { type: "address", "restrictSearchableAttributes": "postcode", hitsPerPage: 1 })
       payload = { query: query }.merge(options)
+      api_url = 'https://places-dsn.algolia.net/1/places/query'
 
-      Net::HTTP.post(
-        URI(self.api_url),
+      response = Net::HTTP.post(
+        URI(api_url),
         payload.to_json,
         self.headers
       )
+
+      case response
+      when Net::HTTPSuccess then
+        success_response(response)
+      else
+        # TODO: track error with sentry?
+        nil
+      end
     end
 
     private
 
-    def headers
+    def self.success_response(response)
+      body = response.body
+      json = JSON.parse(body)
+
+      # We return the first result
+      result = json['hits'].first
+
+      {
+        city: result['city']['default'].first,
+        country: result['country']['default'],
+        country_code: result['country_code'],
+        county: result['country']['default'].first,
+        objectID: result['objectID'],
+        postcodes: result['postcode'],
+        state: result['administrative'].first
+      }
+
+    end
+
+    def self.headers
       {
         accept: "application/json",
         "Content-Type": "application/json",
-        "X-Algolia-Application-Id": self.app_id,
-        "X-Algolia-API-Key": self.api_key
+        "X-Algolia-Application-Id": SiteSetting.debtcollective_algolia_app_id,
+        "X-Algolia-API-Key": SiteSetting.debtcollective_algolia_api_key
       }
     end
   end

--- a/lib/algolia_places_client.rb
+++ b/lib/algolia_places_client.rb
@@ -19,9 +19,7 @@ module Debtcollective
       when Net::HTTPSuccess then
         success_response(response)
       else
-        if Module.const_defined?('Raven')
-          Raven.capture_message("Error while making Algolia Places request", extra: { status: response.status, body: response.body })
-        end
+        Raven.capture_message("Error while making Algolia Places request", extra: { status: response.status, body: response.body }) if defined?(Raven)
 
         nil
       end

--- a/lib/services/base_service.rb
+++ b/lib/services/base_service.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Debtcollective
+  module BaseService
+    def self.capture_message(message, attrs = {})
+      if Module.const_defined?('Raven')
+        Raven.capture_message(message, attrs)
+      end
+    end
+  end
+end

--- a/lib/services/base_service.rb
+++ b/lib/services/base_service.rb
@@ -2,9 +2,7 @@
 module Debtcollective
   module BaseService
     def self.capture_message(message, attrs = {})
-      if Module.const_defined?('Raven')
-        Raven.capture_message(message, attrs)
-      end
+      Raven.capture_message(message, attrs) if defined?(Raven)
     end
   end
 end

--- a/lib/services/user_profile_service.rb
+++ b/lib/services/user_profile_service.rb
@@ -54,7 +54,7 @@ module Debtcollective
     def self.set_user_field_value_by_name(user, field_name, value)
       field = UserField.find_by(name: field_name)
 
-      user.user_fields[field.id.to_s] = value if field
+      user.custom_fields["user_field_#{field.id}"] = value if field
     end
   end
 end

--- a/lib/services/user_profile_service.rb
+++ b/lib/services/user_profile_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Debtcollective
+  class UserProfileService
+    include BaseService
+
+    def self.extend_user_profile(user)
+      # get_address_info(user.zip)
+      # update user fields with address info (city, state and other useful info)
+      # add_user_to_state group
+    end
+
+    def self.get_address_info(zip: null)
+      # from zip code get
+      # - state
+      # - city
+      { state: 'valid state', city: 'valid city' }
+    end
+
+    def self.add_user_to_group(user)
+      state = user.custom_fields['user_field_1']
+
+      return if state.nil?
+
+      group_name = state.split.map(&:camelize).join
+      group = Group.find_by_name(group_name)
+
+      if group.nil?
+        capture_message("A state group wasn't found", extra: { user_id: user.id, state: state, group_name: group_name })
+        return
+      end
+
+      group.add(user)
+      group.save
+    end
+  end
+end

--- a/lib/sso.rb
+++ b/lib/sso.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'jwt'
 
 module Debtcollective
   class SSO

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,6 +16,7 @@ def load_plugin
     ../lib/extensions/users/omniauth_callbacks_controller.rb
     ../lib/services/base_service.rb
     ../lib/services/user_profile_service.rb
+    ../app/jobs/extend_user_profile.rb
   ].each do |path|
     load File.expand_path(path, __FILE__)
   end
@@ -28,7 +29,7 @@ after_initialize do
     Discourse.current_user_provider = Debtcollective::CurrentUserProvider
 
     DiscourseEvent.on(:user_created) do |user|
-      Debtcollective::UserProfileService.execute(user)
+      Jobs.enqueue(:extend_user_profile, { user_id: user.id })
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -5,16 +5,17 @@
 # version: 1.0.0
 # authors: @debtcollective
 
-require 'jwt'
-
 def load_plugin
   %w[
     ../config/routes.rb
     ../lib/sso.rb
     ../lib/current_user_provider.rb
+    ../lib/algolia_places_client.rb
     ../lib/extensions/session_controller.rb
     ../lib/extensions/users_controller.rb
     ../lib/extensions/users/omniauth_callbacks_controller.rb
+    ../lib/services/base_service.rb
+    ../lib/services/user_profile_service.rb
   ].each do |path|
     load File.expand_path(path, __FILE__)
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -26,5 +26,9 @@ after_initialize do
     load_plugin()
 
     Discourse.current_user_provider = Debtcollective::CurrentUserProvider
+
+    DiscourseEvent.on(:user_created) do |user|
+      Debtcollective::UserProfileService.execute(user)
+    end
   end
 end

--- a/spec/lib/algolia_places_client_spec.rb
+++ b/spec/lib/algolia_places_client_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Debtcollective::AlgoliaPlacesClient do
+  describe "#query" do
+    it "returns search using zip code" do
+      expect(true).to be_true
+    end
+  end
+end

--- a/spec/lib/algolia_places_client_spec.rb
+++ b/spec/lib/algolia_places_client_spec.rb
@@ -4,7 +4,84 @@ require 'rails_helper'
 describe Debtcollective::AlgoliaPlacesClient do
   describe "#query" do
     it "returns search using zip code" do
-      expect(true).to be_true
+      # Response from the Algolia places API
+      query_response = <<-END
+      {"hits":[{"country":{"de":"Vereinigte Staaten von Amerika","ru":"Соединённые Штаты Америки","pt":"Estados Unidos da América","it":"Stati Uniti d'America","fr":"États-Unis d'Amérique","hu":"Amerikai Egyesült Államok","es":"Estados Unidos de América","zh":"美国","ar":"الولايات المتّحدة الأمريكيّة","default":"United States of America","ja":"アメリカ合衆国","pl":"Stany Zjednoczone Ameryki","ro":"Statele Unite ale Americii","nl":"Verenigde Staten van Amerika"},"is_country":false,"city":{"default":["Canton"]},"is_highway":false,"importance":17,"_tags":["place/island","country/us","address","source/osm","place"],"postcode":["13617"],"county":{"default":["Saint Lawrence County"],"ru":["округ Сент-Лоренс"]},"population":6076,"country_code":"us","is_city":false,"is_popular":false,"administrative":["New York"],"admin_level":15,"is_suburb":false,"locale_names":{"default":["Willow Island"]},"_geoloc":{"lat":44.5947,"lng":-75.1739},"objectID":"99718134_83903548","_highlightResult":{"country":{"de":{"value":"Vereinigte Staaten von Amerika","matchLevel":"none","matchedWords":[]},"ru":{"value":"Соединённые Штаты Америки","matchLevel":"none","matchedWords":[]},"pt":{"value":"Estados Unidos da América","matchLevel":"none","matchedWords":[]},"it":{"value":"Stati Uniti d'America","matchLevel":"none","matchedWords":[]},"fr":{"value":"États-Unis d'Amérique","matchLevel":"none","matchedWords":[]},"hu":{"value":"Amerikai Egyesült Államok","matchLevel":"none","matchedWords":[]},"es":{"value":"Estados Unidos de América","matchLevel":"none","matchedWords":[]},"zh":{"value":"美国","matchLevel":"none","matchedWords":[]},"ar":{"value":"الولايات المتّحدة الأمريكيّة","matchLevel":"none","matchedWords":[]},"default":{"value":"United States of America","matchLevel":"none","matchedWords":[]},"ja":{"value":"アメリカ合衆国","matchLevel":"none","matchedWords":[]},"pl":{"value":"Stany Zjednoczone Ameryki","matchLevel":"none","matchedWords":[]},"ro":{"value":"Statele Unite ale Americii","matchLevel":"none","matchedWords":[]},"nl":{"value":"Verenigde Staten van Amerika","matchLevel":"none","matchedWords":[]}},"city":{"default":[{"value":"Canton","matchLevel":"none","matchedWords":[]}]},"postcode":[{"value":"<em>13617</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["13617"]}],"county":{"default":[{"value":"Saint Lawrence County","matchLevel":"none","matchedWords":[]}],"ru":[{"value":"округ Сент-Лоренс","matchLevel":"none","matchedWords":[]}]},"administrative":[{"value":"New York","matchLevel":"none","matchedWords":[]}],"locale_names":{"default":[{"value":"Willow Island","matchLevel":"none","matchedWords":[]}]}}}],"nbHits":1,"processingTimeMS":28,"query":"13617","params":"query=13617&type=address&restrictSearchableAttributes=postcode&hitsPerPage=1","degradedQuery":false}
+      END
+
+      stub_request(:post, "https://places-dsn.algolia.net/1/places/query").
+        with(
+        body: "{\"query\":\"13617\",\"type\":\"address\",\"restrictSearchableAttributes\":\"postcode\",\"hitsPerPage\":1}",
+        headers: {
+        'Accept' => 'application/json',
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Content-Type' => 'application/json',
+        'Host' => 'places-dsn.algolia.net',
+        'User-Agent' => 'Ruby',
+        'X-Algolia-Api-Key' => '',
+        'X-Algolia-Application-Id' => ''
+      }).to_return(status: 200, body: query_response, headers: {})
+
+      json = Debtcollective::AlgoliaPlacesClient.query('13617')
+
+      expect(json[:country_code]).to eq('us')
+      expect(json[:city]).to eq('Canton')
+      expect(json[:state]).to eq('New York')
+      expect(json[:postcodes]).to include('13617')
+    end
+
+    it "returns search using zip code" do
+      # Response from the Algolia places API
+      query_response = <<-END
+      {"hits":[{"country":{"de":"Vereinigte Staaten von Amerika","ru":"Соединённые Штаты Америки","pt":"Estados Unidos da América","it":"Stati Uniti d'America","fr":"États-Unis d'Amérique","hu":"Amerikai Egyesült Államok","es":"Estados Unidos de América","zh":"美国","ar":"الولايات المتّحدة الأمريكيّة","default":"United States of America","ja":"アメリカ合衆国","pl":"Stany Zjednoczone Ameryki","ro":"Statele Unite ale Americii","nl":"Verenigde Staten van Amerika"},"is_country":false,"city":{"ar":["سان فرانسيسكو"],"default":["San Francisco","SF"],"ru":["Сан-Франциско"],"pt":["São Francisco"],"ja":["サンフランシスコ"],"zh":["旧金山"]},"is_highway":true,"importance":26,"_tags":["highway","highway/residential","country/us","address","source/osm"],"postcode":["94118","94115"],"county":{"default":["San Francisco City and County","San Francisco","SF"],"ru":["Сан-Франциско"],"zh":["旧金山市县"]},"population":864816,"country_code":"us","is_city":false,"is_popular":false,"administrative":["California"],"admin_level":15,"is_suburb":false,"locale_names":{"default":["Anzavista Avenue"]},"_geoloc":{"lat":37.7795,"lng":-122.444},"objectID":"170678228_399595260","_highlightResult":{"country":{"de":{"value":"Vereinigte Staaten von Amerika","matchLevel":"none","matchedWords":[]},"ru":{"value":"Соединённые Штаты Америки","matchLevel":"none","matchedWords":[]},"pt":{"value":"Estados Unidos da América","matchLevel":"none","matchedWords":[]},"it":{"value":"Stati Uniti d'America","matchLevel":"none","matchedWords":[]},"fr":{"value":"États-Unis d'Amérique","matchLevel":"none","matchedWords":[]},"hu":{"value":"Amerikai Egyesült Államok","matchLevel":"none","matchedWords":[]},"es":{"value":"Estados Unidos de América","matchLevel":"none","matchedWords":[]},"zh":{"value":"美国","matchLevel":"none","matchedWords":[]},"ar":{"value":"الولايات المتّحدة الأمريكيّة","matchLevel":"none","matchedWords":[]},"default":{"value":"United States of America","matchLevel":"none","matchedWords":[]},"ja":{"value":"アメリカ合衆国","matchLevel":"none","matchedWords":[]},"pl":{"value":"Stany Zjednoczone Ameryki","matchLevel":"none","matchedWords":[]},"ro":{"value":"Statele Unite ale Americii","matchLevel":"none","matchedWords":[]},"nl":{"value":"Verenigde Staten van Amerika","matchLevel":"none","matchedWords":[]}},"city":{"ar":[{"value":"سان فرانسيسكو","matchLevel":"none","matchedWords":[]}],"default":[{"value":"San Francisco","matchLevel":"none","matchedWords":[]},{"value":"SF","matchLevel":"none","matchedWords":[]}],"ru":[{"value":"Сан-Франциско","matchLevel":"none","matchedWords":[]}],"pt":[{"value":"São Francisco","matchLevel":"none","matchedWords":[]}],"ja":[{"value":"サンフランシスコ","matchLevel":"none","matchedWords":[]}],"zh":[{"value":"旧金山","matchLevel":"none","matchedWords":[]}]},"postcode":[{"value":"94118","matchLevel":"none","matchedWords":[]},{"value":"<em>94115</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["94115"]}],"county":{"default":[{"value":"San Francisco City and County","matchLevel":"none","matchedWords":[]},{"value":"San Francisco","matchLevel":"none","matchedWords":[]},{"value":"SF","matchLevel":"none","matchedWords":[]}],"ru":[{"value":"Сан-Франциско","matchLevel":"none","matchedWords":[]}],"zh":[{"value":"旧金山市县","matchLevel":"none","matchedWords":[]}]},"administrative":[{"value":"California","matchLevel":"none","matchedWords":[]}],"locale_names":{"default":[{"value":"Anzavista Avenue","matchLevel":"none","matchedWords":[]}]}}}],"nbHits":1,"processingTimeMS":27,"query":"94115","params":"query=94115&type=address&restrictSearchableAttributes=postcode&hitsPerPage=1","degradedQuery":false}
+      END
+
+      stub_request(:post, "https://places-dsn.algolia.net/1/places/query").
+        with(
+        body: "{\"query\":\"94115\",\"type\":\"address\",\"restrictSearchableAttributes\":\"postcode\",\"hitsPerPage\":1}",
+        headers: {
+        'Accept' => 'application/json',
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Content-Type' => 'application/json',
+        'Host' => 'places-dsn.algolia.net',
+        'User-Agent' => 'Ruby',
+        'X-Algolia-Api-Key' => '',
+        'X-Algolia-Application-Id' => ''
+      }).to_return(status: 200, body: query_response, headers: {})
+
+      json = Debtcollective::AlgoliaPlacesClient.query('94115')
+
+      expect(json[:country_code]).to eq('us')
+      expect(json[:city]).to eq('San Francisco')
+      expect(json[:state]).to eq('California')
+      expect(json[:postcodes]).to include('94115')
+    end
+
+    it "returns search using zip code" do
+      # Response from the Algolia places API
+      query_response = <<-END
+      {"hits":[{"country":{"de":"Mexiko","ru":"Мексика","en":"Mexico","it":"Messico","fr":"Mexique","hu":"Mexikó","zh":"墨西哥","ar":"المكسيك","default":"México","ja":"メキシコ","pl":"Meksyk","ro":"Mexic","nl":"Mexico"},"is_country":false,"city":{"de":["Mexiko-Stadt"],"ru":["Мехико"],"pt":["Cidade do México"],"en":["Mexico City"],"it":["Città del Messico"],"fr":["Mexico"],"hu":["Mexikóváros"],"zh":["墨西哥城"],"ar":["مدينة مكسيكو"],"default":["Ciudad de México","DF","CDMX"],"ja":["メキシコシティ"],"pl":["Meksyk"],"nl":["Mexico-Stad"]},"is_highway":true,"importance":26,"_tags":["highway","highway/residential","country/mx","address","source/osm"],"postcode":["07509","06140","09800","06170"],"county":{"default":["Gustavo A. Madero","Cuauhtémoc","Iztapalapa"]},"population":8555500,"country_code":"mx","is_city":false,"is_popular":false,"administrative":["Ciudad de México"],"admin_level":15,"is_suburb":false,"locale_names":{"default":["Calle Tula"]},"_geoloc":{"lat":19.4738,"lng":-99.0632},"objectID":"170086107_395207047","_highlightResult":{"country":{"de":{"value":"Mexiko","matchLevel":"none","matchedWords":[]},"ru":{"value":"Мексика","matchLevel":"none","matchedWords":[]},"en":{"value":"Mexico","matchLevel":"none","matchedWords":[]},"it":{"value":"Messico","matchLevel":"none","matchedWords":[]},"fr":{"value":"Mexique","matchLevel":"none","matchedWords":[]},"hu":{"value":"Mexikó","matchLevel":"none","matchedWords":[]},"zh":{"value":"墨西哥","matchLevel":"none","matchedWords":[]},"ar":{"value":"المكسيك","matchLevel":"none","matchedWords":[]},"default":{"value":"México","matchLevel":"none","matchedWords":[]},"ja":{"value":"メキシコ","matchLevel":"none","matchedWords":[]},"pl":{"value":"Meksyk","matchLevel":"none","matchedWords":[]},"ro":{"value":"Mexic","matchLevel":"none","matchedWords":[]},"nl":{"value":"Mexico","matchLevel":"none","matchedWords":[]}},"city":{"de":[{"value":"Mexiko-Stadt","matchLevel":"none","matchedWords":[]}],"ru":[{"value":"Мехико","matchLevel":"none","matchedWords":[]}],"pt":[{"value":"Cidade do México","matchLevel":"none","matchedWords":[]}],"en":[{"value":"Mexico City","matchLevel":"none","matchedWords":[]}],"it":[{"value":"Città del Messico","matchLevel":"none","matchedWords":[]}],"fr":[{"value":"Mexico","matchLevel":"none","matchedWords":[]}],"hu":[{"value":"Mexikóváros","matchLevel":"none","matchedWords":[]}],"zh":[{"value":"墨西哥城","matchLevel":"none","matchedWords":[]}],"ar":[{"value":"مدينة مكسيكو","matchLevel":"none","matchedWords":[]}],"default":[{"value":"Ciudad de México","matchLevel":"none","matchedWords":[]},{"value":"DF","matchLevel":"none","matchedWords":[]},{"value":"CDMX","matchLevel":"none","matchedWords":[]}],"ja":[{"value":"メキシコシティ","matchLevel":"none","matchedWords":[]}],"pl":[{"value":"Meksyk","matchLevel":"none","matchedWords":[]}],"nl":[{"value":"Mexico-Stad","matchLevel":"none","matchedWords":[]}]},"postcode":[{"value":"07509","matchLevel":"none","matchedWords":[]},{"value":"<em>06140</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["06140"]},{"value":"09800","matchLevel":"none","matchedWords":[]},{"value":"06170","matchLevel":"none","matchedWords":[]}],"county":{"default":[{"value":"Gustavo A. Madero","matchLevel":"none","matchedWords":[]},{"value":"Cuauhtémoc","matchLevel":"none","matchedWords":[]},{"value":"Iztapalapa","matchLevel":"none","matchedWords":[]}]},"administrative":[{"value":"Ciudad de México","matchLevel":"none","matchedWords":[]}],"locale_names":{"default":[{"value":"Calle Tula","matchLevel":"none","matchedWords":[]}]}}}],"nbHits":1,"processingTimeMS":25,"query":"06140","params":"query=06140&type=address&restrictSearchableAttributes=postcode&hitsPerPage=1","degradedQuery":false}
+      END
+
+      stub_request(:post, "https://places-dsn.algolia.net/1/places/query").
+        with(
+        body: "{\"query\":\"06140\",\"type\":\"address\",\"restrictSearchableAttributes\":\"postcode\",\"hitsPerPage\":1}",
+        headers: {
+        'Accept' => 'application/json',
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Content-Type' => 'application/json',
+        'Host' => 'places-dsn.algolia.net',
+        'User-Agent' => 'Ruby',
+        'X-Algolia-Api-Key' => '',
+        'X-Algolia-Application-Id' => ''
+      }).to_return(status: 200, body: query_response, headers: {})
+
+      json = Debtcollective::AlgoliaPlacesClient.query('06140')
+
+      expect(json[:country_code]).to eq('mx')
+      expect(json[:city]).to eq('Ciudad de México')
+      expect(json[:state]).to eq('Ciudad de México')
+      expect(json[:postcodes]).to include('06140')
     end
   end
 end

--- a/spec/lib/algolia_places_client_spec.rb
+++ b/spec/lib/algolia_places_client_spec.rb
@@ -27,6 +27,7 @@ describe Debtcollective::AlgoliaPlacesClient do
       expect(json[:country_code]).to eq('us')
       expect(json[:city]).to eq('Canton')
       expect(json[:state]).to eq('New York')
+      expect(json[:county]).to eq('Saint Lawrence County')
       expect(json[:postcodes]).to include('13617')
     end
 
@@ -54,6 +55,7 @@ describe Debtcollective::AlgoliaPlacesClient do
       expect(json[:country_code]).to eq('us')
       expect(json[:city]).to eq('San Francisco')
       expect(json[:state]).to eq('California')
+      expect(json[:county]).to eq('San Francisco City and County')
       expect(json[:postcodes]).to include('94115')
     end
 

--- a/spec/lib/services/user_profile_service_spec.rb
+++ b/spec/lib/services/user_profile_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Debtcollective::UserProfileService do
+  describe "#add_user_location_data" do
+    before do
+      @zip_code_user_field = Fabricate(:user_field, name: "Zip Code")
+      @state_user_field = Fabricate(:user_field, name: "State")
+      @city_user_field = Fabricate(:user_field, name: "City")
+      @zip_code = '13617'
+
+      @user = Fabricate(:user,
+        email: "test@example.com",
+        name: "Bruce Wayne",
+        custom_fields: { "user_field_#{@zip_code_user_field.id}": @zip_code }
+      )
+    end
+
+    it "returns sets user location data using zip code" do
+      # Response from the Algolia places API
+      query_response = <<-END
+      {"hits":[{"country":{"de":"Vereinigte Staaten von Amerika","ru":"Соединённые Штаты Америки","pt":"Estados Unidos da América","it":"Stati Uniti d'America","fr":"États-Unis d'Amérique","hu":"Amerikai Egyesült Államok","es":"Estados Unidos de América","zh":"美国","ar":"الولايات المتّحدة الأمريكيّة","default":"United States of America","ja":"アメリカ合衆国","pl":"Stany Zjednoczone Ameryki","ro":"Statele Unite ale Americii","nl":"Verenigde Staten van Amerika"},"is_country":false,"city":{"default":["Canton"]},"is_highway":false,"importance":17,"_tags":["place/island","country/us","address","source/osm","place"],"postcode":["13617"],"county":{"default":["Saint Lawrence County"],"ru":["округ Сент-Лоренс"]},"population":6076,"country_code":"us","is_city":false,"is_popular":false,"administrative":["New York"],"admin_level":15,"is_suburb":false,"locale_names":{"default":["Willow Island"]},"_geoloc":{"lat":44.5947,"lng":-75.1739},"objectID":"99718134_83903548","_highlightResult":{"country":{"de":{"value":"Vereinigte Staaten von Amerika","matchLevel":"none","matchedWords":[]},"ru":{"value":"Соединённые Штаты Америки","matchLevel":"none","matchedWords":[]},"pt":{"value":"Estados Unidos da América","matchLevel":"none","matchedWords":[]},"it":{"value":"Stati Uniti d'America","matchLevel":"none","matchedWords":[]},"fr":{"value":"États-Unis d'Amérique","matchLevel":"none","matchedWords":[]},"hu":{"value":"Amerikai Egyesült Államok","matchLevel":"none","matchedWords":[]},"es":{"value":"Estados Unidos de América","matchLevel":"none","matchedWords":[]},"zh":{"value":"美国","matchLevel":"none","matchedWords":[]},"ar":{"value":"الولايات المتّحدة الأمريكيّة","matchLevel":"none","matchedWords":[]},"default":{"value":"United States of America","matchLevel":"none","matchedWords":[]},"ja":{"value":"アメリカ合衆国","matchLevel":"none","matchedWords":[]},"pl":{"value":"Stany Zjednoczone Ameryki","matchLevel":"none","matchedWords":[]},"ro":{"value":"Statele Unite ale Americii","matchLevel":"none","matchedWords":[]},"nl":{"value":"Verenigde Staten van Amerika","matchLevel":"none","matchedWords":[]}},"city":{"default":[{"value":"Canton","matchLevel":"none","matchedWords":[]}]},"postcode":[{"value":"<em>13617</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["13617"]}],"county":{"default":[{"value":"Saint Lawrence County","matchLevel":"none","matchedWords":[]}],"ru":[{"value":"округ Сент-Лоренс","matchLevel":"none","matchedWords":[]}]},"administrative":[{"value":"New York","matchLevel":"none","matchedWords":[]}],"locale_names":{"default":[{"value":"Willow Island","matchLevel":"none","matchedWords":[]}]}}}],"nbHits":1,"processingTimeMS":28,"query":"13617","params":"query=13617&type=address&restrictSearchableAttributes=postcode&hitsPerPage=1","degradedQuery":false}
+      END
+
+      stub_request(:post, "https://places-dsn.algolia.net/1/places/query").
+        with(
+        body: "{\"query\":\"#{@zip_code}\",\"type\":\"address\",\"restrictSearchableAttributes\":\"postcode\",\"hitsPerPage\":1}",
+        headers: {
+        'Accept' => 'application/json',
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Content-Type' => 'application/json',
+        'Host' => 'places-dsn.algolia.net',
+        'User-Agent' => 'Ruby',
+        'X-Algolia-Api-Key' => '',
+        'X-Algolia-Application-Id' => ''
+      }).to_return(status: 200, body: query_response, headers: {})
+
+      Debtcollective::UserProfileService.add_user_location_data(@user)
+      tdc_user_location = JSON.parse(@user.custom_fields['tdc_user_location'])
+
+      expect(tdc_user_location['state']).to eq('New York')
+      expect(tdc_user_location['city']).to eq('Canton')
+      expect(tdc_user_location['zip_code']).to eq('13617')
+      expect(tdc_user_location['postcodes']).to include('13617')
+      expect(tdc_user_location['geoloc']).to eq({ "lat" => 44.5947, "lng" => -75.1739 })
+      expect(@user.user_fields[@state_user_field.id.to_s]).to eq('New York')
+      expect(@user.user_fields[@city_user_field.id.to_s]).to eq('Canton')
+    end
+  end
+end

--- a/spec/lib/services/user_profile_service_spec.rb
+++ b/spec/lib/services/user_profile_service_spec.rb
@@ -36,6 +36,7 @@ describe Debtcollective::UserProfileService do
       }).to_return(status: 200, body: query_response, headers: {})
 
       Debtcollective::UserProfileService.add_user_location_data(@user)
+      @user.reload
       tdc_user_location = JSON.parse(@user.custom_fields['tdc_user_location'])
 
       expect(tdc_user_location['state']).to eq('New York')

--- a/spec/lib/services/user_profile_service_spec.rb
+++ b/spec/lib/services/user_profile_service_spec.rb
@@ -47,4 +47,29 @@ describe Debtcollective::UserProfileService do
       expect(@user.user_fields[@city_user_field.id.to_s]).to eq('Canton')
     end
   end
+
+  describe "#add_user_to_state_group" do
+    it 'adds user to specific group given their US state' do
+      # create user custom field
+      user_field = UserField.create({
+        name: "State",
+        description: "State",
+        field_type: "state",
+        required: true,
+        editable: true,
+        show_on_profile: false,
+        show_on_user_card: false,
+      })
+      # create New York group
+      state = "New York"
+      group = Fabricate(:group, name: "NewYork", full_name: "New York members")
+      # create user with State == New York
+      user = Fabricate(:user, custom_fields: { "user_field_#{user_field.id}": state })
+
+      Debtcollective::UserProfileService.add_user_to_state_group(user)
+
+      group.reload
+      expect(group.users).to include(user)
+    end
+  end
 end


### PR DESCRIPTION
**What:** Extend users profile after signup.

**Why:** Closes https://app.asana.com/0/1168997577035609/1179368978953605

**How:**

- Use Algolia Places API to fetch more state and city from zip code after the user signups
- Combine https://github.com/debtcollective/discourse-debtcollective-signup-fields backend part into this plugin, as part of having just one plugin for our backend extensions.