### PR TITLE
check if the user should be redirected to wizard after signup with social accounts

### DIFF
--- a/lib/custom_wizard.rb
+++ b/lib/custom_wizard.rb
@@ -1,0 +1,50 @@
+module Debtcollective
+  class CustomWizard
+    class << self
+      def collectives
+        @collectives ||= [
+          "court_fines_and_fees",
+          "student_debt",
+          "housing_debt",
+          "auto_loans",
+          "payday_loans",
+          "medical_debt",
+          "for_profit_colleges",
+          "credit_card_debt",
+          "solidarity_bloc"
+        ]
+      end
+
+      def add_user_to_groups(user, groups)
+        groups.each do |group_name, is_member|
+          group = Group.find_by(name: group_name)
+
+          if is_member
+            group.add(user)
+          else
+            group.remove(user)
+          end
+
+          group.save
+        end
+      end
+
+      def solidarity_pm_content(user)
+        "Hello @#{user.username}!\n\nThank you for offering to help in solidarity with people in debt. Tell us a little about yourself and what skills you have to share so we can get started."
+      end
+
+      def send_solidarity_pm(user)
+        bloc_manager = User.find_by_username(SiteSetting.debtcollective_solidarity_message_author)
+        bloc_manager ||= Discourse.system_user
+
+        PostCreator.create(bloc_manager,
+          archetype: Archetype.private_message,
+          title: SiteSetting.debtcollective_solidarity_message_title,
+          raw: solidarity_pm_content(user),
+          target_usernames: [user.username],
+          target_group_names: []
+        )
+      end
+    end
+  end
+end

--- a/lib/extensions/users_controller.rb
+++ b/lib/extensions/users_controller.rb
@@ -5,12 +5,18 @@ module Debtcollective
     # Add redirection to sso_destination_url if avaiable
     def account_created
       if current_user.present?
+        # CustomWizard plugin has side effect when calling Wizard.user_requires_completion?(@user)
+        # We still need this side effect so the wizard is rendered when the user goes to Discourse for the first time
+        custom_wizard_redirect = Wizard.user_requires_completion?(current_user)
+
         if SiteSetting.enable_sso_provider && payload = cookies.delete(:sso_payload)
           return redirect_to(session_sso_provider_url + "?" + payload)
         elsif sso_destination_url = cookies.delete(:sso_destination_url)
           return redirect_to(sso_destination_url)
         elsif destination_url = cookies.delete(:destination_url)
           return redirect_to(destination_url)
+        elsif custom_wizard_redirect
+          redirect_to(wizard_path)
         else
           return redirect_to(path('/'))
         end

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,6 +11,7 @@ def load_plugin
     ../lib/sso.rb
     ../lib/current_user_provider.rb
     ../lib/algolia_places_client.rb
+    ../lib/custom_wizard.rb
     ../lib/extensions/session_controller.rb
     ../lib/extensions/users_controller.rb
     ../lib/extensions/users/omniauth_callbacks_controller.rb
@@ -22,9 +23,38 @@ def load_plugin
   end
 end
 
+def custom_wizard_extensions
+  # welcome wizard step handler
+  # we only process the 'debt_types' step
+  ::CustomWizard::Builder.add_step_handler('welcome') do |builder|
+    current_step = builder.updater.step
+    updater = builder.updater
+    wizard = builder.wizard
+    user = wizard.user
+
+    if current_step.id == "debt_types"
+      # fields returns an ActiveParams object
+      # we cast it as hash
+      step_data = updater.fields.to_h
+
+      groups = step_data.slice(*Debtcollective::CustomWizard.collectives)
+      groups_to_join = groups.select { |key, value| groups[key] == true }
+
+      if groups_to_join.any?
+        Debtcollective::CustomWizard.add_user_to_groups(user, groups)
+
+        if groups_to_join.include?('solidarity_bloc')
+          Debtcollective::CustomWizard.send_solidarity_pm(user)
+        end
+      end
+    end
+  end
+end
+
 after_initialize do
   if SiteSetting.enable_debtcollective_sso
     load_plugin()
+    custom_wizard_extensions()
 
     Discourse.current_user_provider = Debtcollective::CurrentUserProvider
 


### PR DESCRIPTION
**What:** fix check if the user should be redirected to wizard after signup with social accounts

https://www.loom.com/share/fb3064d7d81a486abf0476d57bcff422

**Why:** Fixes https://app.asana.com/0/1168997577035609/1179962743609641

**How:**

- Check if we need to redirect the user to the custom wizard after the account is created with social authentication
- Fork discourse-custom-wizard and make the fix there https://github.com/debtcollective/discourse-custom-wizard/commit/8047bbd867c5e9a6d3ce1381050536858b1c6825. The issue here is when using social networks to create an account, `user.first_seen_at` comes with a value and the Custom wizard plugin is expecting this to be null. We introduce a fix to check either `first_seen_at` is empty or `first_seen_at` equals `last_seen_at` which is the case for the first login.