### PR TITLE
feat(invites): redirect user to member hub after they accept an invite

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,3 +3,5 @@ en:
     enable_debtcollective_sso: 'Enable debtcollective-sso plugin'
     debtcollective_algolia_app_id: 'Algolia Places App ID'
     debtcollective_algolia_api_key: 'Algolia Places API key'
+    debtcollective_algolia_api_key: 'Algolia Places API key'
+    debtcollective_redirect_url_after_accept_invitation: 'Redirect URL after user accepts an invite. ex https://debtcollective.org/hub'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,8 +17,11 @@ plugins:
     default: ''
     shadowed_by_global: true
   debtcollective_solidarity_message_author:
-    default: "system"
+    default: 'system'
     client: false
   debtcollective_solidarity_message_title:
-    default: "Solidarity Bloc"
+    default: 'Solidarity Bloc'
+    client: false
+  debtcollective_redirect_url_after_accept_invitation:
+    default: 'http://lvh.me:8000/hub'
     client: false

--- a/lib/extensions/invites_controller.rb
+++ b/lib/extensions/invites_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+# https://github.com/discourse/discourse/blob/master/app/controllers/invites_controller.rb
+module Debtcollective
+  module InvitesController
+    def perform_accept_invitation
+      params.require(:id)
+      params.permit(:email, :username, :name, :password, :timezone, user_custom_fields: {})
+      invite = Invite.find_by(invite_key: params[:id])
+
+      if invite.present?
+        begin
+          user = if invite.is_invite_link?
+            invite.redeem_invite_link(email: params[:email], username: params[:username], name: params[:name], password: params[:password], user_custom_fields: params[:user_custom_fields], ip_address: request.remote_ip)
+          else
+            invite.redeem(username: params[:username], name: params[:name], password: params[:password], user_custom_fields: params[:user_custom_fields], ip_address: request.remote_ip)
+          end
+
+          if user.present?
+            log_on_user(user) if user.active?
+            user.update_timezone_if_missing(params[:timezone])
+            post_process_invite(user)
+            response = { success: true }
+          else
+            response = { success: false, message: I18n.t('invite.not_found_json') }
+          end
+
+          if user.present? && user.active?
+            topic = invite.topics.first
+            response[:redirect_to] = path("/")
+            response[:redirect_to] = topic.present? ? path("#{topic.relative_url}") : path("/")
+
+            # If this is a new user or first login, redirect
+            # we only set it if topic invite is nil
+            redirect_to = SiteSetting.debtcollective_redirect_url_after_accept_invitation
+
+            if (user.new_user? || !user.seen_before?) && redirect_to.present? && topic.blank?
+              response[:redirect_to] = SiteSetting.debtcollective_redirect_url_after_accept_invitation
+            end
+          elsif user.present?
+            response[:message] = I18n.t('invite.confirm_email')
+          end
+
+          render json: response
+        rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+          render json: {
+            success: false,
+            errors: e.record&.errors&.to_hash || {},
+            message: I18n.t('invite.error_message')
+          }
+        rescue Invite::UserExists => e
+          render json: { success: false, message: [e.message] }
+        end
+      else
+        render json: { success: false, message: I18n.t('invite.not_found_json') }
+      end
+    end
+  end
+
+  ::InvitesController.class_eval do
+    prepend Debtcollective::InvitesController
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -15,6 +15,7 @@ def load_plugin
     ../lib/custom_wizard.rb
     ../lib/extensions/session_controller.rb
     ../lib/extensions/users_controller.rb
+    ../lib/extensions/invites_controller.rb
     ../lib/extensions/users/omniauth_callbacks_controller.rb
     ../lib/services/base_service.rb
     ../lib/services/user_profile_service.rb


### PR DESCRIPTION
**What:** redirect user to member hub after they accept a Discourse invite

https://www.loom.com/share/c63a8578cbd14df1b6c354949ace0a1a

**Why:** Closes https://app.asana.com/0/1196225495304457/1196225495304504

**How:**

- Add setting `debtcollective_redirect_url_after_accept_invitation`
- Set `redirect_to` param to `debtcollective_redirect_url_after_accept_invitation` if it's present
