### PR TITLE
generate username only for admin api calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ There are cases where want to restart the server in order to see changes. Do to 
 1. Get into the Discourse docker container. `./launcher enter web`
 1. Stop unicorn. `sv stop unicorn`
 1. Compile new assets `su discourse -c 'bundle exec rake assets:precompile'`
+1. Upload assets to S3 `bundle exec rake s3:upload_assets`
 1. Start unicorn. `sv start unicorn`

--- a/lib/extensions/users_controller.rb
+++ b/lib/extensions/users_controller.rb
@@ -97,9 +97,8 @@ module Debtcollective
         return fail_with("login.wrong_invite_code")
       end
 
-      # Generate username if it's empty and it's an API call
-      # We use to create user accounts from the Membership app
-      if is_api? && params[:username].blank?
+      # We use this to create accounts from the Membership app
+      if is_api? && guardian.is_admin? && params[:username].blank?
         params[:username] = UserNameSuggester.suggest(user_params[:email])
       end
 

--- a/lib/extensions/users_controller.rb
+++ b/lib/extensions/users_controller.rb
@@ -5,18 +5,12 @@ module Debtcollective
     # Add redirection to sso_destination_url if avaiable
     def account_created
       if current_user.present?
-        # CustomWizard plugin has side effect when calling Wizard.user_requires_completion?(@user)
-        # We still need this side effect so the wizard is rendered when the user goes to Discourse for the first time
-        custom_wizard_redirect = Wizard.user_requires_completion?(current_user)
-
         if SiteSetting.enable_sso_provider && payload = cookies.delete(:sso_payload)
           return redirect_to(session_sso_provider_url + "?" + payload)
         elsif sso_destination_url = cookies.delete(:sso_destination_url)
           return redirect_to(sso_destination_url)
         elsif destination_url = cookies.delete(:destination_url)
           return redirect_to(destination_url)
-        elsif custom_wizard_redirect
-          redirect_to(wizard_path)
         else
           return redirect_to(path('/'))
         end
@@ -203,6 +197,7 @@ module Debtcollective
           email_token = user.email_tokens.create!(email: user.email)
 
           response[:email_token] = email_token.token
+          response[:username] = user.username
         end
 
         render json: response

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "UsersController" do
+  describe 'Create user via api' do
+    context "with an admin account" do
+      it 'returns user data including auto generated username' do
+        post_user_params ={
+          name: "orlando test",
+          username: nil,
+          password: "strongpassword",
+          email: "orlando@test.com"
+        }
+        generated_username = UserNameSuggester.suggest(post_user_params[:email])
+        api_key = Fabricate(:api_key, user: Fabricate(:admin))
+
+        post "/u.json", params: post_user_params, headers: { HTTP_API_KEY: api_key.key }
+        json = response.parsed_body
+
+        expect(response.status).to eq(200)
+        expect(json['success']).to eq(true)
+        expect(json['message']).to be_present
+        expect(json['username']).to eq(generated_username)
+      end
+    end
+  end
+end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -24,5 +24,25 @@ describe "UsersController" do
         expect(json['username']).to eq(generated_username)
       end
     end
+
+    context "with a user account" do
+      it 'returns an error' do
+        post_user_params ={
+          name: "orlando test",
+          username: nil,
+          password: "strongpassword",
+          email: "orlando@test.com"
+        }
+        generated_username = UserNameSuggester.suggest(post_user_params[:email])
+        api_key = Fabricate(:api_key, user: Fabricate(:user))
+
+        post "/u.json", params: post_user_params, headers: { HTTP_API_KEY: api_key.key }
+        json = response.parsed_body
+
+        expect(response.status).to eq(400)
+        expect(json['errors']).to be_present
+        expect(json['success']).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
**What:** generate username only for admin api calls

**Why:** Make sure only our API integrations can use this endpoint

**How:**

- use Guardian to check for admin account